### PR TITLE
Add ability to save dates

### DIFF
--- a/Sources/Defaults.swift
+++ b/Sources/Defaults.swift
@@ -127,7 +127,7 @@ public final class Defaults {
     /// - Returns: A boolean value indicating if the type is primitive.
     private func isPrimitive<ValueType>(type: ValueType.Type) -> Bool {
         switch type {
-        case is String.Type, is Bool.Type, is Int.Type, is Float.Type, is Double.Type:
+        case is String.Type, is Bool.Type, is Int.Type, is Float.Type, is Double.Type, is Date.Type:
             return true
         default:
             return false

--- a/Tests/DefaultsTests.swift
+++ b/Tests/DefaultsTests.swift
@@ -129,6 +129,24 @@ class DefaultsKitTests: XCTestCase {
         
     }
     
+    func testDate() {
+        
+        // Given
+        let value = Date()
+        let key = Key<Date>("key")
+        
+        // When
+        defaults.set(value, for: key)
+        
+        // Then
+        let hasKey = defaults.has(key)
+        XCTAssertTrue(hasKey)
+        
+        let savedValue = defaults.get(for: key)
+        XCTAssertEqual(savedValue, value)
+        
+    }
+    
     func testSet() {
         
         // Given


### PR DESCRIPTION
While working with this I noticed I could not save `Date`'s which is a requirement of mine. In the past I've done this the old fashion way:

```swift
UserDefaults.standard.set(Date(), forKey: SHOULD_REFRESH)
UserDefaults.standard.synchronize()
```
I'm not sure if `isPrimitive` name still fits but thought I'd leave that up to you. I'd love to use `DefaultsKit` with `Date`'s. Please consider my PR.

Thanks!