### PR TITLE
Enable store RawRepresentable directly

### DIFF
--- a/DefaultsKit.xcodeproj/project.pbxproj
+++ b/DefaultsKit.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		075B52F32170909200E358B1 /* RawRepresentableMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 075B52F12170908A00E358B1 /* RawRepresentableMock.swift */; };
+		075B52F42170909200E358B1 /* RawRepresentableMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 075B52F12170908A00E358B1 /* RawRepresentableMock.swift */; };
+		075B52F52170909300E358B1 /* RawRepresentableMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 075B52F12170908A00E358B1 /* RawRepresentableMock.swift */; };
 		A0AC4AAA1F43853D0070F91D /* DefaultsKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A0AC4AA01F43853D0070F91D /* DefaultsKit.framework */; };
 		A0AC4AAF1F43853D0070F91D /* DefaultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0AC4AAE1F43853D0070F91D /* DefaultsTests.swift */; };
 		A0AC4AB11F43853D0070F91D /* DefaultsKit.h in Headers */ = {isa = PBXBuildFile; fileRef = A0AC4AA31F43853D0070F91D /* DefaultsKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -50,6 +53,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		075B52F12170908A00E358B1 /* RawRepresentableMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawRepresentableMock.swift; sourceTree = "<group>"; };
 		A0AC4AA01F43853D0070F91D /* DefaultsKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DefaultsKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A0AC4AA31F43853D0070F91D /* DefaultsKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DefaultsKit.h; sourceTree = "<group>"; };
 		A0AC4AA41F43853D0070F91D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -153,6 +157,7 @@
 				A0AC4AAE1F43853D0070F91D /* DefaultsTests.swift */,
 				A0AC4AB01F43853D0070F91D /* Info.plist */,
 				A0DFDB0D20CD8C58004A4C2F /* PersonMock.swift */,
+				075B52F12170908A00E358B1 /* RawRepresentableMock.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -405,6 +410,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				075B52F32170909200E358B1 /* RawRepresentableMock.swift in Sources */,
 				A0AC4AAF1F43853D0070F91D /* DefaultsTests.swift in Sources */,
 				A0DFDB0A20CD8C4F004A4C2F /* DefaultsKey + keys.swift in Sources */,
 				A0DFDB0E20CD8C58004A4C2F /* PersonMock.swift in Sources */,
@@ -431,6 +437,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				075B52F52170909300E358B1 /* RawRepresentableMock.swift in Sources */,
 				A0F001271F48D12900617715 /* DefaultsTests.swift in Sources */,
 				A0DFDB0C20CD8C4F004A4C2F /* DefaultsKey + keys.swift in Sources */,
 				A0DFDB1020CD8C58004A4C2F /* PersonMock.swift in Sources */,
@@ -441,6 +448,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				075B52F42170909200E358B1 /* RawRepresentableMock.swift in Sources */,
 				A0F001381F48D35700617715 /* DefaultsTests.swift in Sources */,
 				A0DFDB0B20CD8C4F004A4C2F /* DefaultsKey + keys.swift in Sources */,
 				A0DFDB0F20CD8C58004A4C2F /* PersonMock.swift in Sources */,

--- a/Sources/Defaults.swift
+++ b/Sources/Defaults.swift
@@ -152,3 +152,28 @@ public final class Defaults {
     
 }
 
+// MARK: ValueType with RawRepresentable conformance
+
+extension Defaults {
+    /// Returns the value associated with the specified key.
+    ///
+    /// - Parameter key: The key.
+    /// - Returns: A `ValueType` or nil if the key was not found.
+    public func get<ValueType: RawRepresentable>(for key: Key<ValueType>) -> ValueType? where ValueType.RawValue: Codable {
+        let convertedKey = Key<ValueType.RawValue>(key._key)
+        if let raw = get(for: convertedKey) {
+            return ValueType(rawValue: raw)
+        }
+        return nil
+    }
+
+    /// Sets a value associated with the specified key.
+    ///
+    /// - Parameters:
+    ///   - some: The value to set.
+    ///   - key: The associated `Key<ValueType>`.
+    public func set<ValueType: RawRepresentable>(_ value: ValueType, for key: Key<ValueType>) where ValueType.RawValue: Codable {
+        let convertedKey = Key<ValueType.RawValue>(key._key)
+        set(value.rawValue, for: convertedKey)
+    }
+}

--- a/Tests/DefaultsTests.swift
+++ b/Tests/DefaultsTests.swift
@@ -106,7 +106,7 @@ class DefaultsKitTests: XCTestCase {
         XCTAssertEqual(savedValue, value)
         
     }
-    
+
     func testBool() {
         
         // Given
@@ -139,6 +139,37 @@ class DefaultsKitTests: XCTestCase {
         let savedValue = defaults.get(for: .dateKey)
         XCTAssertEqual(savedValue, value)
         
+    }
+
+    func testEnum() {
+
+        // Give
+        let value = EnumMock.three
+
+        // When
+        defaults.set(value, for: .enumKey)
+
+        // Then
+        let hasKey = defaults.has(.enumKey)
+        XCTAssert(hasKey)
+
+        let savedValue = defaults.get(for: .enumKey)
+        XCTAssertEqual(savedValue, value)
+    }
+
+    func testOptionSet() {
+        // Give
+        let value = OptionSetMock.option3
+
+        // When
+        defaults.set(value, for: .optionSetKey)
+
+        // Then
+        let hasKey = defaults.has(.optionSetKey)
+        XCTAssert(hasKey)
+
+        let savedValue = defaults.get(for: .optionSetKey)
+        XCTAssertEqual(savedValue, value)
     }
     
     func testSet() {

--- a/Tests/RawRepresentableMock.swift
+++ b/Tests/RawRepresentableMock.swift
@@ -1,5 +1,5 @@
 //
-//  DefaultsKey + keys.swift
+//  PersonMock.swift
 //
 //  Copyright (c) 2017 - 2018 Nuno Manuel Dias
 //
@@ -23,17 +23,14 @@
 //
 
 import Foundation
-@testable import DefaultsKit
 
-extension DefaultsKey {
-    static let integerKey = Key<Int>("integerKey")
-    static let floatKey = Key<Float>("floatKey")
-    static let doubleKey = Key<Double>("doubleKey")
-    static let stringKey = Key<String>("stringKey")
-    static let boolKey = Key<Bool>("boolKey")
-    static let dateKey = Key<Date>("dateKey")
-    static let enumKey = Key<EnumMock>("enumKey")
-    static let optionSetKey = Key<OptionSetMock>("optionSetKey")
-    static let arrayOfIntegersKey = Key<[Int]>("arrayOfIntegersKey")
-    static let personMockKey = Key<PersonMock>("personMockKey")
+enum EnumMock: Int, Codable {
+    case one, two, three
+}
+
+struct OptionSetMock: OptionSet, Codable {
+    let rawValue: Int
+    static let option1 = OptionSetMock(rawValue: 1)
+    static let option2 = OptionSetMock(rawValue: 2)
+    static let option3 = OptionSetMock(rawValue: 3)
 }


### PR DESCRIPTION
I need to store enum and optionSet in DefaultsKit without writing duplicated code

After add these two extension methods. Any `RawRepresentable` can be get and set directly.

```swift
public func get<ValueType: RawRepresentable>(for key: Key<ValueType>) -> ValueType? where ValueType.RawValue: Codable
public func set<ValueType: RawRepresentable>(_ value: ValueType, for key: Key<ValueType>) where ValueType.RawValue: Codable
```

