### PR TITLE
Update ios deployment target for Xcode14.3

### DIFF
--- a/DefaultsKit.xcodeproj/project.pbxproj
+++ b/DefaultsKit.xcodeproj/project.pbxproj
@@ -611,6 +611,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.nmdias.DefaultsKit;
 				PRODUCT_NAME = DefaultsKit;
@@ -632,6 +633,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.nmdias.DefaultsKit;
 				PRODUCT_NAME = DefaultsKit;
@@ -646,6 +648,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				INFOPLIST_FILE = Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.nmdias.DefaultsKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -659,6 +662,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				INFOPLIST_FILE = Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.nmdias.DefaultsKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
close #35 

When I tried to build this project with Xcode14.3 (beta1), the build failed because this project does not have a deployment target and is using iOS 8.0, which is no longer supported. 
Therefore, the minimum supported version should be set to iOS 11.0.

